### PR TITLE
Add default value to repos

### DIFF
--- a/TVModel/Network.swift
+++ b/TVModel/Network.swift
@@ -56,7 +56,6 @@ public final class Network: Networking {
         }
     }
     
-    
     public func searchUser(username: String) -> Observable<UserEntity> {
         let urlContent = "https://api.github.com/users/\(username)"
         let url = NSURL(string: urlContent.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet())!)!

--- a/TVModel/RepositoryEntity.swift
+++ b/TVModel/RepositoryEntity.swift
@@ -33,7 +33,11 @@ extension RepositoryEntity {
         
         self.id = id
         self.slug = slug
-        self.description = description
+        if description.isEmpty {
+            self.description = "Description not provided"
+        }else {
+            self.description = description
+        }
     }
     
     struct Mapper{


### PR DESCRIPTION
When a repo hasn't got a description the item cell looks unfinished. Now has a default value "No description provided"
